### PR TITLE
[FIX] resolve #102 fix useQuery queryKey

### DIFF
--- a/React/src/Profile/Profile.tsx
+++ b/React/src/Profile/Profile.tsx
@@ -62,7 +62,7 @@ const getHistory = async (user: string): Promise<Array<HistoryData>> => {
 
 function Profile() {
     const userName: string = window.location.pathname.split('/')[2] || '@'; 
-    const { data: profileData, isLoading: profileLoading, isError: profileError } = useQuery<ProfileData>('profile-data', ()=>getProfileData(userName), {retry: false, staleTime: 60 * 1000});
+    const { data: profileData, isLoading: profileLoading, isError: profileError } = useQuery<ProfileData>('profile-data-' + userName, ()=>getProfileData(userName), {retry: false, staleTime: 60 * 1000});
     const { data: history, isLoading: historyLoading, isError: histotyError } = useQuery<Array<HistoryData>>('history-data', ()=>getHistory(userName), {retry: false, staleTime: 60 * 1000});
     const socket = useContext(SocketContext);
     const { showInvite, closeInvite, inviteData } = useInviteGame(socket);


### PR DESCRIPTION
resolve issue #102
useQuery로 보관하고 있던 data의 key가 모두 동일하였기 때문에 fresh한 데이터가 존재한다고 여겨져서 생긴 현상
queryKey에 userName을 더하여 각각의 유저 프로필 데이터를 따로 관리하게 함으로써 해결