### PR TITLE
[FIX] resolve #107 fix adduser msg on chat

### DIFF
--- a/React/src/Main/Main.tsx
+++ b/React/src/Main/Main.tsx
@@ -112,8 +112,8 @@ function Main() {
 
     socket.on("addUser", (nickname: string) => {
       const newMessage: Message = {
-        nickname: nickname,
-        message: " has joined the room",
+        nickname: "@join",
+        message: nickname + " has joined the room",
       };
       setMessages((prevMessages) => [...prevMessages, newMessage]);
     });
@@ -325,7 +325,7 @@ function Main() {
                             : ""
                     }
                   >
-                    {msg.nickname}: {msg.message}
+                    {msg.nickname === "@join" ? msg.message : (msg.nickname + ': ' + msg.message)}
                   </div>
                 )
             )}


### PR DESCRIPTION
resolve issue #107 

messages에 nickname을 @join(불가능한 닉네임)으로 설정한 message를 추가하여 해당 닉네임을 가진 message는 콜론을 제외하고 띄워지도록 수정했습니다! 이 외에도 채팅 출력 형식 변경을 원하는 것은 새 이슈로 작성해주세요.