### PR TITLE
[FIX] resolve #123 resolve profile data refetch error

### DIFF
--- a/React/src/Profile/Profile.tsx
+++ b/React/src/Profile/Profile.tsx
@@ -62,8 +62,8 @@ const getHistory = async (user: string): Promise<Array<HistoryData>> => {
 
 function Profile() {
     const userName: string = window.location.pathname.split('/')[2] || '@'; 
-    const { data: profileData, isLoading: profileLoading, isError: profileError } = useQuery<ProfileData>('profile-data-' + userName, ()=>getProfileData(userName), {retry: false, staleTime: 60 * 1000});
-    const { data: history, isLoading: historyLoading, isError: histotyError } = useQuery<Array<HistoryData>>('history-data', ()=>getHistory(userName), {retry: false, staleTime: 60 * 1000});
+    const { data: profileData, isLoading: profileLoading, isError: profileError } = useQuery<ProfileData>('profile-data-' + userName, ()=>getProfileData(userName), {retry: false, staleTime: 60 * 1000, refetchOnMount: 'always'});
+    const { data: history, isLoading: historyLoading, isError: histotyError } = useQuery<Array<HistoryData>>('history-data' + userName, ()=>getHistory(userName), {retry: false, staleTime: 60 * 1000, refetchOnMount: 'always'});
     const socket = useContext(SocketContext);
     const { showInvite, closeInvite, inviteData } = useInviteGame(socket);
     const { showStart, closeStart, startData } = useStartGame(socket);


### PR DESCRIPTION
resolve issue #123 

useQuery에서 data refetch를 하는 옵션 중 refetchOnMount를 always로 설정하여 stale 될 때 이외에도 mount 될 때마다 api call을 하도록 설정하였습니다. #105 처럼 history에도 queryKey를 유저마다 설정해주어 다른 사람의 history가 뜨지 않게, refetchOnMount 옵션을 주어 페이지에 접근 할 때마다 업데이트하도록 수정하였습니다.